### PR TITLE
handle format 's%' more than 60

### DIFF
--- a/lib/jquery-backward-timer.src.js
+++ b/lib/jquery-backward-timer.src.js
@@ -114,10 +114,15 @@
                     value = value.replace('h%', dhms.d * 24 + dhms.h)
                 }
 
-                value = value
-                        .replace('m%', plugin.methods._check_leading_zero(dhms.m))
-                        .replace('s%', plugin.methods._check_leading_zero(dhms.s))
-
+                if ( value.indexOf("d%") === -1 && value.indexOf("h%") === -1 && value.indexOf("m%") === -1 ) { 
+                  value = value
+                          .replace('s%', ( plugin.methods._check_leading_zero(dhms.s + dhms.m*60 + dhms.h*3600 + dhms.d*86400 ) ) )
+                }
+                else
+                	value = value
+                			.replace('m%', plugin.methods._check_leading_zero(dhms.m))
+                   		    .replace('s%', plugin.methods._check_leading_zero(dhms.s))
+                
                 if (plugin.seconds_left < 0) {
                     value = '-' + value
                 }


### PR DESCRIPTION
i use a timer with format: 's%' but values greater than 60 seconds are not display properly 

{ seconds: 60, format 's%' } => timer display value is 60, 59, 58 .... 0

{ seconds: 120, format 's%' } => timer display value should be 120, 119, 118....
